### PR TITLE
Handle broken shared file error gracefully

### DIFF
--- a/src/libsync/discoveryphase.cpp
+++ b/src/libsync/discoveryphase.cpp
@@ -384,7 +384,14 @@ void DiscoverySingleDirectoryJob::directoryListingIteratedSlot(QString file, con
         propertyMapToFileStat(map, file_stat.get());
         if (file_stat->type == ItemTypeDirectory)
             file_stat->size = 0;
-        if (file_stat->type == ItemTypeSkip
+        if (remotePerm.hasPermission(RemotePermissions::IsShared) && file_stat->etag.isEmpty()) {
+            /* Handle broken shared file error gracefully instead of stopping sync in the desktop client.
+               DO not set _error */
+            qCWarning(lcDiscovery)
+                << "Missing path to a share :" << file << file_stat->path << file_stat->type << file_stat->size
+                << file_stat->modtime << file_stat->remotePerm.toString()
+                << file_stat->etag << file_stat->file_id;
+        } else if (file_stat->type == ItemTypeSkip
             || file_stat->size == -1
             || file_stat->remotePerm.isNull()
             || file_stat->etag.isEmpty()


### PR DESCRIPTION
Throw error for broken shared folder/file but allow syncing to continue without causing Desktop client to break totally.

https://github.com/nextcloud/desktop/issues/908
https://github.com/nextcloud/desktop/issues/819
